### PR TITLE
Bump ld-find-code-refs-github-action version, fix "detached head" issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM launchdarkly/ld-find-code-refs-github-action:1.1.1
+FROM launchdarkly/ld-find-code-refs-github-action:1.2.0
 
 LABEL com.github.actions.name="LaunchDarkly Code References"
 LABEL com.github.actions.description="Find references to feature flags in your code."


### PR DESCRIPTION
This PR updates the action to point to a version of `ld-find-code-refs` that supports github actions v2.

Addresses https://github.com/launchdarkly/find-code-references/issues/1.