### PR TITLE
Bump ld-find-code-refs-github-action version to 2.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM launchdarkly/ld-find-code-refs-github-action:1.5.0
+FROM launchdarkly/ld-find-code-refs-github-action:2.0.0
 
 LABEL com.github.actions.name="LaunchDarkly Code References"
 LABEL com.github.actions.description="Find references to feature flags in your code."

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This GitHub Action is a utility that automatically populates code references in 
 
 ## Configuration
 
-Once you've [created a LaunchDarkly access token](https://docs.launchdarkly.com/docs/git-code-references#section-creating-an-access-token), store the newly created access token as a repository secret titled `LD_ACCESS_TOKEN`. Under Settings > Secrets in your GitHub repo, you'll see a link to "Add a new secret".  Click that and paste in your access token and click "Save secret". 
+Once you've [created a LaunchDarkly access token](https://docs.launchdarkly.com/docs/git-code-references#section-creating-an-access-token), store the newly created access token as a repository secret titled `LD_ACCESS_TOKEN`. Under Settings > Secrets in your GitHub repo, you'll see a link to "Add a new secret".  Click that and paste in your access token and click "Save secret".
 
 (For help storing this see the [GitHub docs](https://help.github.com/en/articles/creating-a-github-action).)
- 
+
 Next, create a new Actions workflow in your selected GitHub repository. If you don't already have a workflow file, you'll need to create a new file titled `action.yml` in the `.github/workflows` directory of your repository.  Under "Edit new file", paste the following code:
 
 ```yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: LaunchDarkly Code References
-      uses: launchdarkly/find-code-references@v5
+      uses: launchdarkly/find-code-references@v7
       with:
         githubToken: ${{ secrets.GITHUB_TOKEN }}
         accessToken: ${{ secrets.LD_ACCESS_TOKEN }}
@@ -43,6 +43,6 @@ If the action fails, there may be a problem with your configuration. To investig
 
 ## Additional Options
 
-Additional configuration options for more environmental variables can be found at the bottom of the [LaunchDarkly GitHub Action documentation](https://docs.launchdarkly.com/docs/github-actions#section-additional-configuration-options).
+Additional configuration options can be found at the bottom of the [LaunchDarkly GitHub Action documentation](https://docs.launchdarkly.com/docs/github-actions#section-additional-configuration-options).
 
 For information about the underlying LaunchDarkly Code References command-line tool, take a look at [this repository](https://github.com/launchdarkly/ld-find-code-refs).

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   color: gray-dark
 inputs:
   projKey:
-    description: 'Key of the LaunchDarkly project associated with this repository.'
+    description: 'Key of the LaunchDarkly project associated with this repository. Found under Account Settings -> Projects in the LaunchDarkly dashboard.'
     required: true
   accessToken:
     description: 'Token with write access to LaunchDarkly project.'

--- a/action.yml
+++ b/action.yml
@@ -19,16 +19,15 @@ inputs:
       The number of context lines above and below a code reference for the job to send to LaunchDarkly. By default, the flag finder will not send any context lines to LaunchDarkly. If < 0, no source code will be sent to LaunchDarkly. If 0, only the lines containing flag references will be sent. If > 0, will send that number of context lines above and below the flag reference. A maximum of 5 context lines may be provided.
     default: 2
   debug:
-    description: Enables verbose debug logging.	
+    description: Enables verbose debug logging.
     default: false
-  delimiters:
-    description: Specifies additional delimiters used to match flag keys. Must be a non-control ASCII character. If more than one character is provided in `delimiters`, each character will be treated as a separate delimiter. Will only match flag keys with surrounded by any of the specified delimeters. This option may also be specified multiple times for multiple delimiters. By default, only flags delimited by single-quotes, double-quotes, and backticks will be matched.
-  exclude:
-    description:
-      A regular expression (PCRE) defining the files, file types, and directories which the job should exclude. Partial matches are allowed. 
   ignoreServiceErrors:
     description: If enabled, the scanner will terminate with exit code 0 when the LaunchDarkly API is unreachable or returns an unexpected response.
     default: false
+  lookback:
+    description: Sets the number of Git commits to search in history for
+whether a feature flag was removed from code. May be set to 0 to disabled this feature. Setting this option to a high value will increase search time.
+    default: 10
   githubToken:
     description: 'Token to access your GitHub repository. This is only needed if the code has not yet been checkout out in a prior step.'
 runs:
@@ -40,7 +39,6 @@ runs:
     LD_BASE_URI: ${{ inputs.baseUri }}
     LD_CONTEXT_LINES: ${{ inputs.contextLines }}
     LD_DEBUG: ${{ inputs.debug }}
-    LD_DELIMITERS: ${{ inputs.delimiters }}
-    LD_EXCLUDE: ${{ inputs.exclude }}
     LD_IGNORE_SERVICE_ERRORS: ${{ inputs.ignoreServiceErrors }}
+    LD_LOOKBACK: ${{ inputs.lookback }}
     GITHUB_TOKEN: ${{ inputs.githubToken }}


### PR DESCRIPTION
Update to the latest version of `ld-find-code-refs`.