### PR TITLE
Remove GitHub token

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ jobs:
     - name: LaunchDarkly Code References
       uses: launchdarkly/find-code-references@v9
       with:
-        githubToken: ${{ secrets.GITHUB_TOKEN }}
         accessToken: ${{ secrets.LD_ACCESS_TOKEN }}
         projKey: YOUR_PROJECT_KEY
 ```

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
 whether a feature flag was removed from code. May be set to 0 to disabled this feature. Setting this option to a high value will increase search time.'
     default: 10
   githubToken:
-    description: Token to access your GitHub repository. Since there's a deafult, this is typically not supplied by the user.
+    description: Token to access your GitHub repository. Since there's a default, this is typically not supplied by the user.
     default: ${{github.token}}
 runs:
   using: 'docker'

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,8 @@ inputs:
 whether a feature flag was removed from code. May be set to 0 to disabled this feature. Setting this option to a high value will increase search time.'
     default: 10
   githubToken:
-    description: 'Token to access your GitHub repository. This is only needed if the code has not yet been checkout out in a prior step.'
+    description: Token to access your GitHub repository. Since there's a deafult, this is typically not supplied by the user.
+    default: ${{github.token}}
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -28,9 +28,6 @@ inputs:
     description: 'Sets the number of Git commits to search in history for
 whether a feature flag was removed from code. May be set to 0 to disabled this feature. Setting this option to a high value will increase search time.'
     default: 10
-  githubToken:
-    description: Token to access your GitHub repository. Since there's a default, this is typically not supplied by the user.
-    default: ${{github.token}}
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -42,4 +39,3 @@ runs:
     LD_DEBUG: ${{ inputs.debug }}
     LD_IGNORE_SERVICE_ERRORS: ${{ inputs.ignoreServiceErrors }}
     LD_LOOKBACK: ${{ inputs.lookback }}
-    GITHUB_TOKEN: ${{ inputs.githubToken }}


### PR DESCRIPTION
Fixes #12 

GitHub Actions can contribute a default value for the `githubToken` input by specifying `default: ${{github.token}}` removing the need for the extra boilerplate that users must add to their workflows.  This technique is used in many of the GitHub created actions such as checkout, setup-node, stale, etc.

- https://github.com/actions/checkout/blob/main/action.yml#L24
- https://github.com/actions/setup-node/blob/main/action.yml#L21
- https://github.com/actions/stale/blob/main/action.yml#L8