### PR TITLE
Clarify `action.yml` naming confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Once you've [created a LaunchDarkly access token](https://docs.launchdarkly.com/
 
 (For help storing this see the [GitHub docs](https://help.github.com/en/articles/creating-a-github-action).)
 
-Next, create a new Actions workflow in your selected GitHub repository. If you don't already have a workflow file, you'll need to create a new file titled `action.yml` in the `.github/workflows` directory of your repository.  Under "Edit new file", paste the following code:
+Next, create a new Actions workflow in your selected GitHub repository (e.g. `code-references.yml`) in the `.github/workflows` directory of your repository.  Under "Edit new file", paste the following code:
 
 ```yaml
 on: push
@@ -29,9 +29,7 @@ jobs:
         projKey: YOUR_PROJECT_KEY
 ```
 
-We strongly recommend that you update the second `uses` attribute value to reference the latest tag in the [launchdarkly/find-code-references repository](https://github.com/launchdarkly/find-code-references). This will pin your workflow to a particular version of the `launchdarkly/find-code-references` action.
-
-If you already have a `action.yml` file, copy and paste the above `launchDarklyCodeReferences` job declaration into the `jobs` section in your existing `action.yml` file.  If you wish to verify that you've pasted the above correctly, you can go into the visual editor and ensure that there are no syntax errors. `projKey` refers to the key of the LaunchDarkly project associated with this repository.
+We strongly recommend that you update the second `uses` attribute value to reference the latest tag in the [launchdarkly/find-code-references repository](https://github.com/launchdarkly/find-code-references). This will pin your workflow to a particular version of the `launchdarkly/find-code-references` action. Also, make sure to change `projKey` to the key of the LaunchDarkly project associated with this repository.
 
 Commit this file under a new branch.  Submit as a PR to your code reviewers to be merged into your master branch.  You do not need to have this branch merged into the master for code references to appear in the LaunchDarkly UI for your flags; code references will appear for this newly created branch.
 


### PR DESCRIPTION
The readme of this action makes it a bit confusing for new users who wish to use this action due to the recommendation of creating a very specifically named `action.yml` file.  While this is the required naming convention when creating an action, GitHub Actions workflow files can be named whatever you want such as build.yml, launch-darkly.yml, code-references.yml, etc.

This PR updates the readme to remove the specific instructions of creating an `action.yml` file in favor of a recommended name like `code-references.yml` without specifically requiring that name.