### PR TITLE
Bump ld-find-code-refs-github-action version to 2.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM launchdarkly/ld-find-code-refs-github-action:2.1.0
+FROM launchdarkly/ld-find-code-refs-github-action:2.2.2
 
 LABEL com.github.actions.name="LaunchDarkly Code References"
 LABEL com.github.actions.description="Find references to feature flags in your code."

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jobs:
       with:
         fetch-depth: 11 # This value must be set if the lookback configuration option is not disabled for find-code-references. Read more: https://github.com/launchdarkly/ld-find-code-refs#searching-for-unused-flags-extinctions
     - name: LaunchDarkly Code References
-      uses: launchdarkly/find-code-references@v9
+      uses: launchdarkly/find-code-references@v10
       with:
         githubToken: ${{ secrets.GITHUB_TOKEN }}
         accessToken: ${{ secrets.LD_ACCESS_TOKEN }}


### PR DESCRIPTION
This will add support for `repoName` to the github action.