### PR TITLE
Update version of code refs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM launchdarkly/ld-find-code-refs-github-action:2.2.2
+FROM launchdarkly/ld-find-code-refs-github-action:2.4.0
 
 LABEL com.github.actions.name="LaunchDarkly Code References"
 LABEL com.github.actions.description="Find references to feature flags in your code."

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jobs:
       with:
         fetch-depth: 11 # This value must be set if the lookback configuration option is not disabled for find-code-references. Read more: https://github.com/launchdarkly/ld-find-code-refs#searching-for-unused-flags-extinctions
     - name: LaunchDarkly Code References
-      uses: launchdarkly/find-code-references@v12
+      uses: launchdarkly/find-code-references@v13
       with:
         accessToken: ${{ secrets.LD_ACCESS_TOKEN }}
         projKey: YOUR_PROJECT_KEY

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
     description:
       The number of context lines above and below a code reference for the job to send to LaunchDarkly. By default, the flag finder will not send any context lines to LaunchDarkly. If < 0, no source code will be sent to LaunchDarkly. If 0, only the lines containing flag references will be sent. If > 0, will send that number of context lines above and below the flag reference. A maximum of 5 context lines may be provided.
     default: 2
+  allowTags:
+    description: Enables storing references for tags. The tag will be listed as a branch.
+    default: false
   debug:
     description: Enables verbose debug logging.
     default: false


### PR DESCRIPTION
Use new version of [code refs library](https://github.com/launchdarkly/ld-find-code-refs)

Includes support for `--allowTags` param
 - See: https://github.com/launchdarkly/ld-find-code-refs/pull/168
