### PR TITLE
Pass allowTags input to docker img

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,7 @@ runs:
     LD_REPO_NAME: ${{ inputs.repoName }}
     LD_BASE_URI: ${{ inputs.baseUri }}
     LD_CONTEXT_LINES: ${{ inputs.contextLines }}
+    LD_ALLOW_TAGS: ${{ inputs.allowTags }}
     LD_DEBUG: ${{ inputs.debug }}
     LD_IGNORE_SERVICE_ERRORS: ${{ inputs.ignoreServiceErrors }}
     LD_LOOKBACK: ${{ inputs.lookback }}


### PR DESCRIPTION
Fixes: https://github.com/launchdarkly/ld-find-code-refs/issues/187

allowTags input option was added to GitHub action, but wasn't properly passed to find flags script

Tested with this config

```yaml
on: release
name: Find flag references
jobs:
  find_flags:
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@master
      with:
        fetch-depth: 0 # This value must be set if the lookback configuration option is not disabled for find-code-references.
    - name: find_flags
      uses: launchdarkly/find-code-references@jwhite/sc-134020/tag-name-detection-in-code-refs-not-working
      with:
        accessToken: ${{ secrets.LD_ACCESS_TOKEN }}
        projKey: jwhite-code-refs
        allowTags: true
        debug: true
        lookback: 0
```