### PR TITLE
Update CODEOWNERS: rename team-fm-next to team-fm-foundations

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @launchdarkly/team-fm-next
+* @launchdarkly/team-fm-foundations


### PR DESCRIPTION
## Summary

Replaces `@launchdarkly/team-fm-next` with `@launchdarkly/team-fm-foundations` in the CODEOWNERS file to reflect the team rename.

This is one of several PRs making this change across the launchdarkly org.

## Review & Testing Checklist for Human

- [ ] Verify that `@launchdarkly/team-fm-foundations` is a valid GitHub team in the launchdarkly org
- [ ] Confirm no other references to `team-fm-next` remain in this repo

### Notes

Repos updated as part of this effort: `ld-find-code-refs`, `find-code-references-in-pull-request`, `find-code-references`, `ld-vscode`, `ld-openapi`. The `agent-skills` repo already had the correct team name.

Link to Devin session: https://app.devin.ai/sessions/8abe80d07e414755864c1b9c67215686
Requested by: @kparkinson-ld