### PR TITLE
chore: update to ld-find-code-refs 2.16.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM launchdarkly/ld-find-code-refs-github-action:2.14.0
+FROM launchdarkly/ld-find-code-refs-github-action:2.16.0
 
 LABEL com.github.actions.name="LaunchDarkly Code References"
 LABEL com.github.actions.description="Find references to feature flags in your code."

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
       with:
         fetch-depth: 11 # This value must be set if the lookback configuration option is not disabled for find-code-references. Read more: https://github.com/launchdarkly/ld-find-code-refs#searching-for-unused-flags-extinctions
     - name: LaunchDarkly Code References
-      uses: launchdarkly/find-code-references@v2.14.0
+      uses: launchdarkly/find-code-references@v2.16.0
       with:
         accessToken: ${{ secrets.LD_ACCESS_TOKEN }}
         projKey: LD_PROJECT_KEY
@@ -71,7 +71,7 @@ jobs:
       with:
         fetch-depth: 11 # This value must be set if the lookback configuration option is not disabled for find-code-references. Read more: https://github.com/launchdarkly/ld-find-code-refs#searching-for-unused-flags-extinctions
     - name: LaunchDarkly Code References
-      uses: launchdarkly/find-code-references@v2.14.0
+      uses: launchdarkly/find-code-references@v2.16.0
       with:
         accessToken: ${{ secrets.LD_ACCESS_TOKEN }}
         projKey: LD_PROJECT_KEY


### PR DESCRIPTION
## Summary

Points the action at `ld-find-code-refs` 2.16.0, which was released today: https://github.com/launchdarkly/ld-find-code-refs/releases/tag/v2.16.0

The headline fix is out-of-memory failures when generating filepattern aliases on large repositories ([ld-find-code-refs#604](https://github.com/launchdarkly/ld-find-code-refs/pull/604)). On a repo with ~80MB of matched source and ~160 flags, the scan was OOM-killed before producing any output. Users pinned to `@v2` or `@v2.14.0` are still hitting that until this merges.

Requested in [ld-find-code-refs#607](https://github.com/launchdarkly/ld-find-code-refs/issues/607).

## What changed

| File | Change |
| --- | --- |
| `Dockerfile` | `FROM launchdarkly/ld-find-code-refs-github-action:2.14.0` → `:2.16.0` |
| `README.md` | pinned version in both workflow examples → `@v2.16.0` |

Both files were copied verbatim from `build/metadata/github-actions/` in `launchdarkly/ld-find-code-refs`, which is the source of truth for them. `action.yml` was already identical and is untouched.

## Why this is a manual PR

`scripts/release/targets/gha.sh` normally does this automatically during the upstream release: it copies the metadata files here, commits, tags, force-moves `v2`, and creates the release. That target (`publish_gha`) has been commented out since [ld-find-code-refs#593](https://github.com/launchdarkly/ld-find-code-refs/pull/593) in January 2026, so it's being done by hand.

Direct pushes to `main` are rejected by rulesets, which is also why the upstream release workflow can't complete on its own — hence the PR rather than a bot push.

## After merge

1. Tag `v2.16.0` at the merge commit.
2. Force-move the `v2` tag so `@v2` users get the fix.
3. Create the `v2.16.0` release.

## Note on version numbering

Jumps 2.14.0 → 2.16.0. 2.15.0 was never released — an incomplete release run in January 2026 published its Docker images and then failed, leaving no tag or release behind, so that number was already burned.
